### PR TITLE
Initialize ASP.NET Core API skeleton

### DIFF
--- a/Calendar.Api/Calendar.Api.csproj
+++ b/Calendar.Api/Calendar.Api.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/Calendar.Api/Controllers/CalculationResultsController.cs
+++ b/Calendar.Api/Controllers/CalculationResultsController.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using Calendar.Api.Data;
+using Calendar.Api.Models;
+
+namespace Calendar.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CalculationResultsController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+
+        public CalculationResultsController(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET api/calculationresults
+        [HttpGet]
+        public IEnumerable<IntervalCalculationResult> GetResults()
+        {
+            return _context.IntervalCalculationResults.ToList();
+        }
+    }
+}

--- a/Calendar.Api/Controllers/CalculationsController.cs
+++ b/Calendar.Api/Controllers/CalculationsController.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Mvc;
+using Calendar.Api.Data;
+using Calendar.Api.Models;
+
+namespace Calendar.Api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CalculationsController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+
+        public CalculationsController(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        // POST api/calculations
+        [HttpPost]
+        public IActionResult CreateCalculation([FromBody] IntervalCalculation request)
+        {
+            // Placeholder implementation
+            _context.IntervalCalculations.Add(request);
+            _context.SaveChanges();
+            return CreatedAtAction(nameof(GetResult), new { id = request.Id }, request);
+        }
+
+        // GET api/calculations/{id}/result
+        [HttpGet("{id}/result")]
+        public ActionResult<IntervalCalculationResult> GetResult(int id)
+        {
+            var result = _context.IntervalCalculationResults.FirstOrDefault(r => r.IntervalCalculationId == id);
+            if (result == null)
+            {
+                return NotFound();
+            }
+            return result;
+        }
+    }
+}

--- a/Calendar.Api/Data/AppDbContext.cs
+++ b/Calendar.Api/Data/AppDbContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Calendar.Api.Models;
+
+namespace Calendar.Api.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<CalendarDate> CalendarDates { get; set; }
+        public DbSet<IntervalCalculation> IntervalCalculations { get; set; }
+        public DbSet<IntervalCalculationResult> IntervalCalculationResults { get; set; }
+    }
+}

--- a/Calendar.Api/Migrations/README.txt
+++ b/Calendar.Api/Migrations/README.txt
@@ -1,0 +1,2 @@
+This folder would normally contain EF Core migration files.
+Since dotnet tools are unavailable in this environment, no migrations were generated.

--- a/Calendar.Api/Models/CalendarDate.cs
+++ b/Calendar.Api/Models/CalendarDate.cs
@@ -1,0 +1,8 @@
+namespace Calendar.Api.Models
+{
+    public class CalendarDate
+    {
+        public int Id { get; set; }
+        public DateTime Date { get; set; }
+    }
+}

--- a/Calendar.Api/Models/IntervalCalculation.cs
+++ b/Calendar.Api/Models/IntervalCalculation.cs
@@ -1,0 +1,9 @@
+namespace Calendar.Api.Models
+{
+    public class IntervalCalculation
+    {
+        public int Id { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+    }
+}

--- a/Calendar.Api/Models/IntervalCalculationResult.cs
+++ b/Calendar.Api/Models/IntervalCalculationResult.cs
@@ -1,0 +1,9 @@
+namespace Calendar.Api.Models
+{
+    public class IntervalCalculationResult
+    {
+        public int Id { get; set; }
+        public int IntervalCalculationId { get; set; }
+        public int DaysBetween { get; set; }
+    }
+}

--- a/Calendar.Api/Program.cs
+++ b/Calendar.Api/Program.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Calendar.Api.Data;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=calendar.db"));
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.MapControllers();
+
+app.Run();

--- a/Calendar.Api/appsettings.json
+++ b/Calendar.Api/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=calendar.db"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# Calendar
-Different Calendars
+# Calendar API
+
+This repository contains a basic ASP.NET Core Web API project with placeholder controllers and data models. The project demonstrates an EF Core setup using SQLite for persistence. Migrations were not generated because .NET tooling isn't available in this environment.


### PR DESCRIPTION
## Summary
- start an ASP.NET Core Web API project (skeleton because dotnet tooling isn't available)
- add placeholder controllers for interval calculations and results
- scaffold EF Core models and DbContext using SQLite
- include a placeholder migrations folder

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647815d700832e9c2656eb411bd13b