### PR TITLE
Add simple lotto dropdown page

### DIFF
--- a/Calendar.Api/Program.cs
+++ b/Calendar.Api/Program.cs
@@ -17,6 +17,10 @@ var app = builder.Build();
 app.UseSwagger();
 app.UseSwaggerUI();
 
+// Serve default static files like wwwroot/index.html
+app.UseDefaultFiles();
+app.UseStaticFiles();
+
 app.MapControllers();
 
 app.Run();

--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Lotto Selector</title>
+</head>
+<body>
+    <h1>Select a lottery</h1>
+    <select id="lotto-select">
+        <option value="Ozlotto">Ozlotto</option>
+        <option value="Powerball">Powerball</option>
+        <option value="Tattslotto">Tattslotto</option>
+    </select>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve static files from the API
- add minimal web page with lotto dropdown

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cddc99a38832e94f2acda7f018cf4