### PR TITLE
Add lottery constants on selection

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -12,5 +12,22 @@
         <option value="Powerball">Powerball</option>
         <option value="Tattslotto">Tattslotto</option>
     </select>
+    <p id="constant-display"></p>
+
+    <script>
+        const lotteryConstants = {
+            Ozlotto: 12395,
+            Powerball: 104116,
+            Tattslotto: 162109
+        };
+
+        const select = document.getElementById('lotto-select');
+        const display = document.getElementById('constant-display');
+
+        select.addEventListener('change', () => {
+            const value = lotteryConstants[select.value];
+            display.textContent = value ? `Constant: ${value}` : '';
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show lottery-specific constants in the sample frontend

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj --nologo` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ce08b6b58832ebdc40d67a2a7dc50