### PR TITLE
Add current date endpoint and frontend display

### DIFF
--- a/Calendar.Api/Controllers/DateController.cs
+++ b/Calendar.Api/Controllers/DateController.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using Calendar.Api.Services;
+using Calendar.Api.Models;
+
+namespace Calendar.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class DateController : ControllerBase
+{
+    private readonly CalendarConversionService _converter;
+
+    public DateController(CalendarConversionService converter)
+    {
+        _converter = converter;
+    }
+
+    // GET api/date/current
+    [HttpGet("current")]
+    public ActionResult<CalendarDate> GetCurrent()
+    {
+        var conv = _converter.Convert(DateTime.UtcNow);
+        return conv;
+    }
+}

--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -14,6 +14,14 @@
     </select>
     <p id="constant-display"></p>
 
+    <h2>Current Date</h2>
+    <ul id="date-info">
+        <li>Gregorian: <span id="gregorian-date"></span></li>
+        <li>Julian: <span id="julian-date"></span></li>
+        <li>Mayan Long Count: <span id="mayan-date"></span></li>
+        <li>Tzolkin: <span id="tzolkin-date"></span></li>
+    </ul>
+
     <script>
         const lotteryConstants = {
             Ozlotto: 12395,
@@ -28,6 +36,20 @@
             const value = lotteryConstants[select.value];
             display.textContent = value ? `Constant: ${value}` : '';
         });
+
+        const gregorianSpan = document.getElementById('gregorian-date');
+        const julianSpan = document.getElementById('julian-date');
+        const mayanSpan = document.getElementById('mayan-date');
+        const tzolkinSpan = document.getElementById('tzolkin-date');
+
+        fetch('/api/date/current')
+            .then(res => res.json())
+            .then(data => {
+                gregorianSpan.textContent = data.gregorianDate;
+                julianSpan.textContent = data.julianDate;
+                mayanSpan.textContent = data.mayanLongCount;
+                tzolkinSpan.textContent = data.tzolkin;
+            });
     </script>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -23,4 +23,10 @@ curl -X POST http://localhost:5000/api/calculations \
 ```
 The response will include the generated dates for the next three days in all supported calendars.
 
+### Get current date conversion
+```
+curl http://localhost:5000/api/date/current
+```
+Returns the current date expressed in Gregorian, Julian, Mayan and Tzolkin forms.
+
 Migrations are not included because `dotnet ef` tools were unavailable in this environment.


### PR DESCRIPTION
## Summary
- add `DateController` with an endpoint to return the current date in multiple calendars
- extend the sample webpage to display current Gregorian, Julian, Mayan and Tzolkin dates
- document the new endpoint in README

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce9f7b388832eb29539a4bd135e47