### PR TITLE
Add Haab calendar conversion

### DIFF
--- a/Calendar.Api/Services/CalendarConversionService.cs
+++ b/Calendar.Api/Services/CalendarConversionService.cs
@@ -12,7 +12,7 @@ public class CalendarConversionService
             JulianDate = ToJulianString(gregorian),
             MayanLongCount = ToMayanLongCount(gregorian),
             Tzolkin = ToTzolkin(gregorian),
-            Haab = ToHaabPlaceholder(gregorian),
+            Haab = ToHaab(gregorian),
             CreatedAt = DateTime.UtcNow
         };
     }
@@ -65,8 +65,21 @@ public class CalendarConversionService
         return $"{number} {name}";
     }
 
-    private static string ToHaabPlaceholder(DateTime date)
+    private static readonly string[] HaabMonths = new[]
     {
-        return $"Haab-{date.DayOfYear % 365}";
+        "Pop", "Wo'", "Sip", "Sotz'", "Sek", "Xul", "Yaxk'in", "Mol",
+        "Ch'en", "Yax", "Sak", "Keh", "Mak", "K'ank'in", "Muwan", "Pax",
+        "K'ayab", "Kumk'u", "Wayeb"
+    };
+
+    private static string ToHaab(DateTime date)
+    {
+        int jdn = JulianDayNumber(date);
+        int days = jdn - 584283;
+        int count = (days + 348) % 365; // 0.0.0.0.0 = 8 Kumk'u
+        int month = count / 20;
+        int day = count % 20;
+        string monthName = HaabMonths[month];
+        return $"{day} {monthName}";
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This project implements a simple multi‑calendar date calculation service based on the BRD requirements. It allows posting a start date and interval specification and returns the corresponding dates across several calendar systems.
 
-Date conversions for the Mayan Long Count and Tzolkin calendars use algorithms
-derived from the open source calendar utilities published by Fourmilab.
+Date conversions for the Mayan Long Count, Tzolkin and Haab calendars use
+algorithms derived from the open source calendar utilities published by
+Fourmilab.
 
 ## Prerequisites
 - .NET SDK 7.0 or later
@@ -30,6 +31,7 @@ The response will include the generated dates for the next three days in all sup
 ```
 curl http://localhost:5000/api/date/current
 ```
-Returns the current date expressed in Gregorian, Julian, Mayan and Tzolkin forms.
+Returns the current date expressed in Gregorian, Julian, Mayan (Long Count),
+Tzolkin and Haab forms.
 
 Migrations are not included because `dotnet ef` tools were unavailable in this environment.


### PR DESCRIPTION
## Summary
- implement Haab solar calendar conversion
- document Haab support in README

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cec8a5fd0832e899c9d71912a59fe