### PR TITLE
Fix lottery dropdown calculations

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -126,21 +126,15 @@
 
             const constant = lotteryConstants[select.value];
             if (!constant || !currentDates) {
-
-            if (select.value !== 'Ozlotto' || !currentDates) {
-
                 calcArea.innerHTML = '';
                 return;
             }
-
 
             const digitsSum = constant
                 .toString()
                 .split('')
                 .map(Number)
                 .reduce((a, b) => a + b, 0);
-
-            const digitsSum = 1 + 2 + 3 + 9 + 5 + 8 + 3 + 0;
 
             const g = new Date(currentDates.gregorianDate);
             const gDay = g.getUTCDate();


### PR DESCRIPTION
## Summary
- correct the `updateCalculations` function in `index.html`
- remove leftover conditional and duplicate lines that prevented calculations from running

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf910cd18832ebf4a22b29f890fab