### PR TITLE
Fix date picker offset

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -188,7 +188,7 @@
             }
 
             if (select.value === 'Ozlotto') {
-                const g = new Date(currentDates.gregorianDate);
+                const g = new Date(currentDates.gregorianDate + 'Z');
                 ozlottoCalculations(g);
                 display.textContent = `Constants: 21, 11`;
                 return;
@@ -201,7 +201,7 @@
                 .reduce((a, b) => a + b, 0);
             display.textContent = `Constant: ${config.constant}`;
 
-            const g = new Date(currentDates.gregorianDate);
+            const g = new Date(currentDates.gregorianDate + 'Z');
             const gDay = g.getUTCDate();
             const gMonth = g.getUTCMonth() + 1;
             const gYear = g.getUTCFullYear();


### PR DESCRIPTION
## Summary
- ensure Ozlotto calculations read the correct date from the picker

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db408f6cc832ea51990372a5a059b