### PR TITLE
Add lotto rules 5 & 6

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -165,16 +165,24 @@
             ].map(Number);
             const r4 = r4Digits.reduce((a, b) => a + b, 0);
 
+            const julianDay = parseInt(currentDates.julianDate.split('/')[0], 10);
+            const r5 = CONST_21 + julianDay;
+            const r6 = CONST_21 - julianDay;
+
             const rule1Exp = `${CONST_21}+${dd}+${mm}+${yearDigits.join('+')}+${const11Digits.join('+')}`;
             const rule2Exp = `${r1Digits.join('+')}+${const21Digits.join('+')}+${CONST_9}`;
             const rule3Exp = `${r2}+${r1Digits.join('+')}+${CONST_9}`;
             const rule4Exp = r4Digits.join('+');
+            const rule5Exp = `${CONST_21}+${julianDay}`;
+            const rule6Exp = `${CONST_21}-${julianDay}`;
 
             calcArea.innerHTML = `<ul>
                 <li>Rule 1: ${rule1Exp} = <strong>${r1}</strong></li>
                 <li>Rule 2: ${rule2Exp} = <strong>${r2}</strong></li>
                 <li>Rule 3: ${rule3Exp} = <strong>${r3}</strong></li>
                 <li>Rule 4: sumDigits(${rule4Exp}) = <strong>${r4}</strong></li>
+                <li>Rule 5: ${rule5Exp} = <strong>${r5}</strong></li>
+                <li>Rule 6: ${rule6Exp} = <strong>${r6}</strong></li>
 
             </ul>`;
         }
@@ -259,7 +267,9 @@
             fetch(`/api/date/convert?date=${dateString}`)
                 .then(res => res.json())
                 .then(data => {
-                    gregorianSpan.textContent = data.gregorianDate;
+                    const g = new Date(data.gregorianDate + 'Z');
+                    const gFormatted = `${g.getUTCDate().toString().padStart(2, '0')}/${(g.getUTCMonth() + 1).toString().padStart(2, '0')}/${g.getUTCFullYear()}`;
+                    gregorianSpan.textContent = gFormatted;
                     julianSpan.textContent = data.julianDate;
                     mayanSpan.textContent = data.mayanLongCount;
                     tzolkinSpan.textContent = data.tzolkin;


### PR DESCRIPTION
## Summary
- expand Ozlotto calculations with rules 5 and 6
- show Gregorian date as `dd/mm/yyyy` on the web page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dbbb80fe0832ebfb6d6d14529ceef