### PR TITLE
Add Hebrew date support

### DIFF
--- a/Calendar.Api/Controllers/CalculationsController.cs
+++ b/Calendar.Api/Controllers/CalculationsController.cs
@@ -47,7 +47,8 @@ public class CalculationsController : ControllerBase
                 JulianDate = conv.JulianDate,
                 MayanLongCount = conv.MayanLongCount,
                 Tzolkin = conv.Tzolkin,
-                Haab = conv.Haab
+                Haab = conv.Haab,
+                HebrewDate = conv.HebrewDate
             };
             _context.IntervalCalculationResults.Add(result);
             calc.Results.Add(result);

--- a/Calendar.Api/Models/CalendarDate.cs
+++ b/Calendar.Api/Models/CalendarDate.cs
@@ -8,6 +8,7 @@ public class CalendarDate
     public string MayanLongCount { get; set; } = string.Empty;
     public string Tzolkin { get; set; } = string.Empty;
     public string Haab { get; set; } = string.Empty;
+    public string HebrewDate { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
     public string? CreatedBy { get; set; }
 }

--- a/Calendar.Api/Models/IntervalCalculationResult.cs
+++ b/Calendar.Api/Models/IntervalCalculationResult.cs
@@ -10,4 +10,5 @@ public class IntervalCalculationResult
     public string MayanLongCount { get; set; } = string.Empty;
     public string Tzolkin { get; set; } = string.Empty;
     public string Haab { get; set; } = string.Empty;
+    public string HebrewDate { get; set; } = string.Empty;
 }

--- a/Calendar.Api/Services/CalendarConversionService.cs
+++ b/Calendar.Api/Services/CalendarConversionService.cs
@@ -14,6 +14,7 @@ public class CalendarConversionService
             MayanLongCount = ToMayanLongCount(dateOnly),
             Tzolkin = ToTzolkin(dateOnly),
             Haab = ToHaab(dateOnly),
+            HebrewDate = ToHebrewString(dateOnly),
             CreatedAt = DateTime.UtcNow
         };
     }
@@ -82,5 +83,14 @@ public class CalendarConversionService
         int day = count % 20;
         string monthName = HaabMonths[month];
         return $"{day} {monthName}";
+    }
+
+    private static string ToHebrewString(DateTime date)
+    {
+        var hebrew = new System.Globalization.HebrewCalendar();
+        int year = hebrew.GetYear(date);
+        int month = hebrew.GetMonth(date);
+        int day = hebrew.GetDayOfMonth(date);
+        return $"{day}/{month}/{year}";
     }
 }

--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -75,6 +75,7 @@
         <li>Mayan Long Count: <span id="mayan-date"></span></li>
         <li>Tzolkin: <span id="tzolkin-date"></span></li>
         <li>Haab: <span id="haab-date"></span></li>
+        <li>Hebrew: <span id="hebrew-date"></span></li>
     </ul>
 
     <script>
@@ -277,6 +278,7 @@
         const mayanSpan = document.getElementById('mayan-date');
         const tzolkinSpan = document.getElementById('tzolkin-date');
         const haabSpan = document.getElementById('haab-date');
+        const hebrewSpan = document.getElementById('hebrew-date');
 
         function loadDate(dateString) {
             fetch(`/api/date/convert?date=${dateString}`)
@@ -289,6 +291,7 @@
                     mayanSpan.textContent = data.mayanLongCount;
                     tzolkinSpan.textContent = data.tzolkin;
                     haabSpan.textContent = data.haab;
+                    hebrewSpan.textContent = data.hebrewDate;
                     currentDates = data;
                     updateCalculations();
                 });

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The response will include the generated dates for the next three days in all sup
 ```
 curl http://localhost:5000/api/date/current
 ```
-Returns the current date expressed in Gregorian, Julian, Mayan (Long Count),
+Returns the current date expressed in Gregorian, Julian, Hebrew, Mayan (Long Count),
 Tzolkin and Haab forms.
 
 Migrations are not included because `dotnet ef` tools were unavailable in this environment.


### PR DESCRIPTION
## Summary
- include Hebrew date in the API conversion model
- compute Hebrew date in `CalendarConversionService`
- store Hebrew date in interval calculation results
- show Hebrew date on the web UI
- mention Hebrew date in README

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc4882014832ea9e2b7382e85cb03