### PR TITLE
Add Julian date sum rules

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -208,6 +208,16 @@
             const r11 = hebrewDay + hebrewMonth + hebrewYearDigits.reduce((a, b) => a + b, 0);
             const rule11Exp = `${hebrewDay}+${hebrewMonth}+${hebrewYearDigits.join('+')}`;
 
+            const julianParts = currentDates.julianDate.split('/');
+            const jDayDigits = julianParts[0].split('').map(Number);
+            const jMonthDigits = julianParts[1].split('').map(Number);
+            const jYearDigits = julianParts[2].split('').map(Number);
+            const r12 = [...jDayDigits, ...jMonthDigits, ...jYearDigits].reduce((a, b) => a + b, 0);
+            const rule12Exp = `${jDayDigits.join('+')}+${jMonthDigits.join('+')}+${jYearDigits.join('+')}`;
+
+            const r13 = r12 + CONST_18;
+            const rule13Exp = `${r12}+${CONST_18}`;
+
             const gDay = dd;
             const jDay = julianDay;
             const hDay = hebrewDay;
@@ -308,8 +318,10 @@
             output += `<li>Rule 9: ${rule9Exp} = <strong>${r9}</strong></li>`;
             output += `<li>Rule 10: ${rule10Exp} = <strong>${r10}</strong></li>`;
             output += `<li>Rule 11: ${rule11Exp} = <strong>${r11}</strong></li>`;
+            output += `<li>Rule 12: ${rule12Exp} = <strong>${r12}</strong></li>`;
+            output += `<li>Rule 13: ${rule13Exp} = <strong>${r13}</strong></li>`;
             additionalResults.forEach((res, idx) => {
-                output += `<li>Rule ${idx + 12}: ${res.exp} = <strong>${res.value}</strong></li>`;
+                output += `<li>Rule ${idx + 14}: ${res.exp} = <strong>${res.value}</strong></li>`;
             });
             output += `</ul>`;
             calcArea.innerHTML = output;


### PR DESCRIPTION
## Summary
- add new rules to calculate Julian date digit sum and sum+18 constant
- output new rules and shift numbering for formulas

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd8a2a78c832eabf79f784b7fffb7