### PR TITLE
Enable Ozlotto calculations for all lotteries

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -335,7 +335,7 @@
                 return;
             }
 
-            if (select.value === 'Ozlotto') {
+            if (['Ozlotto', 'Powerball', 'Tattslotto'].includes(select.value)) {
                 const g = new Date(currentDates.gregorianDate + 'Z');
                 ozlottoCalculations(g);
                 display.textContent = `Constants: 21, 11, 18, 10`;


### PR DESCRIPTION
## Summary
- use the full Ozlotto rule set when selecting Tattslotto or Powerball

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de15a4ad4832eb5664cb62a666ef3