### PR TITLE
Add simple navigation menu

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -10,9 +10,21 @@
             font-family: Arial, Helvetica, sans-serif;
             background: #f5f7fa;
             display: flex;
-            justify-content: center;
+            flex-direction: column;
+            align-items: center;
             padding: 40px 0;
             color: #333;
+        }
+
+        nav.main-nav {
+            margin-bottom: 20px;
+        }
+
+        nav.main-nav a {
+            margin: 0 10px;
+            color: #333;
+            text-decoration: none;
+            font-weight: bold;
         }
 
         .card {
@@ -57,6 +69,10 @@
     </style>
 </head>
 <body>
+    <nav class="main-nav">
+        <a href="index.html">Predict</a>
+        <a href="lotto-entry.html">Enter Numbers</a>
+    </nav>
     <div class="card">
     <h1>Select a lottery</h1>
     <select id="lotto-select">

--- a/Calendar.Api/wwwroot/lotto-entry.html
+++ b/Calendar.Api/wwwroot/lotto-entry.html
@@ -10,9 +10,21 @@
             font-family: Arial, Helvetica, sans-serif;
             background: #f5f7fa;
             display: flex;
-            justify-content: center;
+            flex-direction: column;
+            align-items: center;
             padding: 40px 0;
             color: #333;
+        }
+
+        nav.main-nav {
+            margin-bottom: 20px;
+        }
+
+        nav.main-nav a {
+            margin: 0 10px;
+            color: #333;
+            text-decoration: none;
+            font-weight: bold;
         }
         .card {
             background: #fff;
@@ -53,6 +65,10 @@
     </style>
 </head>
 <body>
+    <nav class="main-nav">
+        <a href="index.html">Predict</a>
+        <a href="lotto-entry.html">Enter Numbers</a>
+    </nav>
     <div class="card">
         <h1>Enter Lotto Numbers</h1>
         <form id="entry-form">


### PR DESCRIPTION
## Summary
- add navigation links between the prediction page and lotto entry page
- tweak styles so nav displays correctly

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f08d5b8a0832ebc3a3fbf0a363064