### PR TITLE
Track lotto match results

### DIFF
--- a/Calendar.Api/Controllers/LottoMatchesController.cs
+++ b/Calendar.Api/Controllers/LottoMatchesController.cs
@@ -33,13 +33,15 @@ namespace Calendar.Api.Controllers
         }
 
         [HttpGet]
-        public IEnumerable<LottoMatch> List(string? lottoName, DateTime? drawDate)
+        public IEnumerable<LottoMatch> List(string? lottoName, DateTime? drawDate, bool? matched)
         {
             var query = _context.LottoMatches.AsQueryable();
             if (!string.IsNullOrEmpty(lottoName))
                 query = query.Where(m => m.LottoName == lottoName);
             if (drawDate.HasValue)
                 query = query.Where(m => m.DrawDate.Date == drawDate.Value.Date);
+            if (matched.HasValue)
+                query = query.Where(m => m.Matched == matched.Value);
             return query.ToList();
         }
     }

--- a/Calendar.Api/Models/LottoMatch.cs
+++ b/Calendar.Api/Models/LottoMatch.cs
@@ -9,6 +9,7 @@ namespace Calendar.Api.Models
         public DateTime DrawDate { get; set; }
         public string Rule { get; set; } = string.Empty;
         public int Number { get; set; }
+        public bool Matched { get; set; }
     }
 }
 

--- a/Calendar.Api/Program.cs
+++ b/Calendar.Api/Program.cs
@@ -10,10 +10,16 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<CalendarConversionService>();
 
 builder.Services.AddDbContextFactory<AppDbContext>(
-    options => options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")),
+    options => options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")),
     ServiceLifetime.Scoped // recommended
 );
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.EnsureCreated();
+}
 
 app.UseSwagger();
 app.UseSwaggerUI();

--- a/Calendar.Api/appsettings.json
+++ b/Calendar.Api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=KAKMA74\\SQLDEV2022;Database=CalendarDb;Trusted_Connection=True;MultipleActiveResultSets=true;Encrypt=False"
+    "DefaultConnection": "Data Source=calendar.db"
   },
 
   "Logging": {

--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -365,6 +365,17 @@
                 if (matched) {
                     matches.push({ rule: r.rule, number: r.value });
                 }
+                fetch('/api/lottomatches', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        lottoName: select.value,
+                        drawDate: datePicker.value,
+                        rule: r.rule,
+                        number: r.value,
+                        matched: matched
+                    })
+                });
                 output += `<li${matched ? ' class="match"' : ''}>${r.rule}: ${r.exp} = <strong>${r.value}</strong></li>`;
             });
             output += '</ul>';
@@ -374,18 +385,6 @@
             if (matches.length > 0) {
                 const nums = matches.map(m => m.number).join(', ');
                 matchDisplay.textContent = `Matched numbers: ${nums}`;
-                matches.forEach(m => {
-                    fetch('/api/lottomatches', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({
-                            lottoName: select.value,
-                            drawDate: datePicker.value,
-                            rule: m.rule,
-                            number: m.number
-                        })
-                    });
-                });
             } else {
                 matchDisplay.textContent = '';
             }

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ database, create a migration for the `LottoEntries` table and apply it:
 dotnet ef migrations add AddLottoEntries -p Calendar.Api -s Calendar.Api
 dotnet ef database update -p Calendar.Api -s Calendar.Api
 ```
+
+Viewing predictions on `/index.html` now records every calculated lotto number.
+Both matched and unmatched numbers are stored via the `/api/lottomatches`
+endpoint and can be queried by lotto name, draw date and match status.


### PR DESCRIPTION
## Summary
- store match status in LottoMatch model
- allow filtering lotto matches by match state
- ensure SQLite database is created on startup
- send match information (matched/unmatched) from UI
- update connection string to SQLite
- document lotto match recording

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj -nologo` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686f16f4abf8832eae3b800b3b63b077