### PR TITLE
Fix database provider

### DIFF
--- a/Calendar.Api/Calendar.Api.csproj
+++ b/Calendar.Api/Calendar.Api.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/Calendar.Api/Program.cs
+++ b/Calendar.Api/Program.cs
@@ -10,7 +10,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<CalendarConversionService>();
 
 builder.Services.AddDbContextFactory<AppDbContext>(
-    options => options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")),
+    options => options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")),
     ServiceLifetime.Scoped // recommended
 );
 var app = builder.Build();

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fourmilab.
 
 ## Prerequisites
 - .NET SDK 7.0 or later
-- SQLite (default connection string is `Data Source=calendar.db`)
+ - SQL Server (default connection string uses a standard `Server=...;Database=...` format)
 
 ## Build and run
 ```


### PR DESCRIPTION
## Summary
- use SqlServer instead of Sqlite in Program.cs
- swap Entity Framework provider to SqlServer
- update README prerequisites to mention SQL Server

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f2079a648832e8a159222edbb96b7