### PR TITLE
Add Powerball rules 76 and 77

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -414,6 +414,13 @@
                         results[idx].exp += `-${CONST_18}`;
                     }
                 }
+
+                const r76 = 22 + ddDigits.reduce((a, b) => a + b, 0);
+                const rule76Exp = `22+${ddDigits.join('+')}`;
+                results.push({ rule: 'Rule 76', value: r76, exp: rule76Exp });
+
+                const r77 = hebrewDay;
+                results.push({ rule: 'Rule 77', value: r77, exp: `${hebrewDay}` });
             }
 
             currentResults = results;


### PR DESCRIPTION
## Summary
- extend Powerball calculations with two new rules
  - Rule 76 = 22 plus the sum of digits of the Gregorian day
  - Rule 77 = current Hebrew calendar day

## Testing
- `dotnet build Calendar.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687060af7010832e9a0da6d9eff11e2a