### PR TITLE
Fix negative rule totals display

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -138,7 +138,8 @@
                 currentEntry.powerball
             ] : [];
             currentResults.forEach(r => {
-                const matched = entryNumbers.includes(r.value);
+                const val = Math.abs(r.value);
+                const matched = entryNumbers.includes(val);
                 fetch('/api/lottomatches', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -146,7 +147,7 @@
                         lottoName: select.value,
                         drawDate: datePicker.value,
                         rule: r.rule,
-                        number: r.value,
+                        number: val,
                         matched: matched
                     })
                 });
@@ -439,11 +440,12 @@
             const matches = [];
             let output = '<ul>';
             results.forEach(r => {
-                const matched = entryNumbers.includes(r.value);
+                const val = Math.abs(r.value);
+                const matched = entryNumbers.includes(val);
                 if (matched) {
-                    matches.push({ rule: r.rule, number: r.value });
+                    matches.push({ rule: r.rule, number: val });
                 }
-                output += `<li${matched ? ' class="match"' : ''}>${r.rule}: ${r.exp} = <strong>${r.value}</strong></li>`;
+                output += `<li${matched ? ' class="match"' : ''}>${r.rule}: ${r.exp} = <strong>${val}</strong></li>`;
             });
             output += '</ul>';
             calcArea.innerHTML = output;


### PR DESCRIPTION
## Summary
- adjust `saveMatches` to use absolute values for totals
- ensure rule calculation display uses absolute values

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687062b85ed4832ebd531299fd296509