### PR TITLE
Add Powerball rule 78 based on Haab date

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -423,8 +423,11 @@
                 const r77Exp = `${r76.toString().split('').join('+')}+${dd}`;
                 results.push({ rule: 'Rule 77', value: r77, exp: r77Exp });
 
-                const r78 = hebrewDay;
-                results.push({ rule: 'Rule 78', value: r78, exp: `${hebrewDay}` });
+                const haab = parseHaab(currentDates.haab);
+                const haabDayDigits = haab.day.toString().split('').map(Number);
+                const r78 = 22 + haabDayDigits.reduce((a, b) => a + b, 0);
+                const rule78Exp = `22+${haabDayDigits.join('+')}`;
+                results.push({ rule: 'Rule 78', value: r78, exp: rule78Exp });
             }
 
             currentResults = results;


### PR DESCRIPTION
## Summary
- update Powerball rule 78 in the web UI
  - use constant 22 and the single digits of the Haab day

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687067c0201c832e82ff92537d292c11