### PR TITLE
Add Powerball rule 79 for lottery calculations

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -428,6 +428,10 @@
                 const r78 = 22 + haabDayDigits.reduce((a, b) => a + b, 0);
                 const rule78Exp = `22+${haabDayDigits.join('+')}`;
                 results.push({ rule: 'Rule 78', value: r78, exp: rule78Exp });
+
+                const r79 = haab.day - tzolkinNumber;
+                const rule79Exp = `${haab.day}-${tzolkinNumber}`;
+                results.push({ rule: 'Rule 79', value: r79, exp: rule79Exp });
             }
 
             currentResults = results;


### PR DESCRIPTION
## Summary
- implement new rule 79 when Powerball calculations are selected
- rule 79 subtracts the Tzolkin value from the Haab day

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870699ac220832e87c5c8f148cda37a