### PR TITLE
Fix Powerball rule 81 calculation

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -459,8 +459,15 @@
 
                 const datePlus9 = new Date(Date.UTC(date.getUTCFullYear() + 9, date.getUTCMonth(), date.getUTCDate()));
                 const mlc = toMayanLongCount(datePlus9);
-                const r81 = mlc.baktun + mlc.katun + mlc.tun + mlc.uinal + mlc.kin;
-                const rule81Exp = `${mlc.baktun}+${mlc.katun}+${mlc.tun}+${mlc.uinal}+${mlc.kin}`;
+                const r81Digits = [
+                    mlc.baktun,
+                    ...mlc.katun.toString().split(''),
+                    ...mlc.tun.toString().split(''),
+                    ...mlc.uinal.toString().split(''),
+                    ...mlc.kin.toString().split('')
+                ].map(Number);
+                const r81 = r81Digits.reduce((a, b) => a + b, 0);
+                const rule81Exp = r81Digits.join('+');
                 results.push({ rule: 'Rule 81', value: r81, exp: rule81Exp });
             }
 


### PR DESCRIPTION
## Summary
- update front-end rule 81 calculation to use single-digit math

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68706dccb3e4832e9285c5ce4627cff9