### PR TITLE
Fix duplicates in lotto match display

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -545,7 +545,8 @@
 
             const matchDisplay = document.getElementById('match-display');
             if (matches.length > 0) {
-                const nums = matches.map(m => m.number).join(', ');
+                const unique = [...new Set(matches.map(m => m.number))];
+                const nums = unique.join(', ');
                 matchDisplay.textContent = `Matched numbers: ${nums}`;
             } else {
                 matchDisplay.textContent = '';


### PR DESCRIPTION
## Summary
- deduplicate match numbers before displaying them

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687075d2ec88832e953eaa86f911dddf