### PR TITLE
Improve lotto match endpoint

### DIFF
--- a/Calendar.Api/Controllers/LottoMatchesController.cs
+++ b/Calendar.Api/Controllers/LottoMatchesController.cs
@@ -44,6 +44,24 @@ namespace Calendar.Api.Controllers
                 query = query.Where(m => m.Matched == matched.Value);
             return query.ToList();
         }
+
+        [HttpGet("numbers")]
+        public IEnumerable<int> Numbers(string? lottoName, DateTime? drawDate, bool? matched, bool distinct = false)
+        {
+            var query = _context.LottoMatches.AsQueryable();
+            if (!string.IsNullOrEmpty(lottoName))
+                query = query.Where(m => m.LottoName == lottoName);
+            if (drawDate.HasValue)
+                query = query.Where(m => m.DrawDate.Date == drawDate.Value.Date);
+            if (matched.HasValue)
+                query = query.Where(m => m.Matched == matched.Value);
+
+            var numbers = query.Select(m => m.Number);
+            if (distinct)
+                numbers = numbers.Distinct();
+
+            return numbers.ToList();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add `/api/lottomatches/numbers` endpoint to query lotto match numbers

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870776edc18832ea797e04e9707fa9e