### PR TITLE
Fix Tattslotto Rule 1 digit handling

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -245,16 +245,14 @@
                     exp: `${digits[0]}+${digits[1]}`
                 };
             }
-            if (digits.length === 3) {
+            if (digits.length >= 3) {
+                const firstTwo = parseInt(`${digits[0]}${digits[1]}`, 10);
+                const restDigits = digits.slice(2);
+                const restSum = restDigits.reduce((a, b) => a + b, 0);
+                const expRest = restDigits.length > 0 ? `+${restDigits.join('+')}` : '';
                 return {
-                    value: (digits[0] + digits[1]) + digits[2],
-                    exp: `(${digits[0]}+${digits[1]})+${digits[2]}`
-                };
-            }
-            if (digits.length === 4) {
-                return {
-                    value: (digits[0] + digits[1]) + digits[2] + digits[3],
-                    exp: `(${digits[0]}+${digits[1]})+${digits[2]}+${digits[3]}`
+                    value: firstTwo + restSum,
+                    exp: `${firstTwo}${expRest}`
                 };
             }
             return {


### PR DESCRIPTION
## Summary
- handle Tattslotto rule 1 when the prime has 3 or more digits by joining the first two digits

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet build --no-restore` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6871ce90fe94832eabf269f36715e404