### PR TITLE
Disable non-Gregorian calendars

### DIFF
--- a/Calendar.Api/Controllers/CalculationsController.cs
+++ b/Calendar.Api/Controllers/CalculationsController.cs
@@ -44,11 +44,11 @@ public class CalculationsController : ControllerBase
                 IntervalCalculationId = calc.Id,
                 StepNumber = i + 1,
                 GregorianDate = conv.GregorianDate,
-                JulianDate = conv.JulianDate,
-                MayanLongCount = conv.MayanLongCount,
-                Tzolkin = conv.Tzolkin,
-                Haab = conv.Haab,
-                HebrewDate = conv.HebrewDate
+                //JulianDate = conv.JulianDate,
+                //MayanLongCount = conv.MayanLongCount,
+                //Tzolkin = conv.Tzolkin,
+                //Haab = conv.Haab,
+                //HebrewDate = conv.HebrewDate
             };
             _context.IntervalCalculationResults.Add(result);
             calc.Results.Add(result);

--- a/Calendar.Api/Models/CalendarDate.cs
+++ b/Calendar.Api/Models/CalendarDate.cs
@@ -4,11 +4,11 @@ public class CalendarDate
 {
     public int Id { get; set; }
     public DateTime GregorianDate { get; set; }
-    public string JulianDate { get; set; } = string.Empty;
-    public string MayanLongCount { get; set; } = string.Empty;
-    public string Tzolkin { get; set; } = string.Empty;
-    public string Haab { get; set; } = string.Empty;
-    public string HebrewDate { get; set; } = string.Empty;
+    //public string JulianDate { get; set; } = string.Empty;
+    //public string MayanLongCount { get; set; } = string.Empty;
+    //public string Tzolkin { get; set; } = string.Empty;
+    //public string Haab { get; set; } = string.Empty;
+    //public string HebrewDate { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
     public string? CreatedBy { get; set; }
 }

--- a/Calendar.Api/Models/IntervalCalculationResult.cs
+++ b/Calendar.Api/Models/IntervalCalculationResult.cs
@@ -6,9 +6,9 @@ public class IntervalCalculationResult
     public int IntervalCalculationId { get; set; }
     public int StepNumber { get; set; }
     public DateTime GregorianDate { get; set; }
-    public string JulianDate { get; set; } = string.Empty;
-    public string MayanLongCount { get; set; } = string.Empty;
-    public string Tzolkin { get; set; } = string.Empty;
-    public string Haab { get; set; } = string.Empty;
-    public string HebrewDate { get; set; } = string.Empty;
+    //public string JulianDate { get; set; } = string.Empty;
+    //public string MayanLongCount { get; set; } = string.Empty;
+    //public string Tzolkin { get; set; } = string.Empty;
+    //public string Haab { get; set; } = string.Empty;
+    //public string HebrewDate { get; set; } = string.Empty;
 }

--- a/Calendar.Api/Services/CalendarConversionService.cs
+++ b/Calendar.Api/Services/CalendarConversionService.cs
@@ -10,87 +10,87 @@ public class CalendarConversionService
         return new CalendarDate
         {
             GregorianDate = dateOnly,
-            JulianDate = ToJulianString(dateOnly),
-            MayanLongCount = ToMayanLongCount(dateOnly),
-            Tzolkin = ToTzolkin(dateOnly),
-            Haab = ToHaab(dateOnly),
-            HebrewDate = ToHebrewString(dateOnly),
+            //JulianDate = ToJulianString(dateOnly),
+            //MayanLongCount = ToMayanLongCount(dateOnly),
+            //Tzolkin = ToTzolkin(dateOnly),
+            //Haab = ToHaab(dateOnly),
+            //HebrewDate = ToHebrewString(dateOnly),
             CreatedAt = DateTime.UtcNow
         };
     }
 
-    private static string ToJulianString(DateTime date)
-    {
-        // Convert to the Julian calendar date string (day/month/year)
-        var julian = new System.Globalization.JulianCalendar();
-        int year = julian.GetYear(date);
-        int month = julian.GetMonth(date);
-        int day = julian.GetDayOfMonth(date);
-        return $"{day}/{month}/{year}";
-    }
+    //private static string ToJulianString(DateTime date)
+    //{
+    //    // Convert to the Julian calendar date string (day/month/year)
+    //    var julian = new System.Globalization.JulianCalendar();
+    //    int year = julian.GetYear(date);
+    //    int month = julian.GetMonth(date);
+    //    int day = julian.GetDayOfMonth(date);
+    //    return $"{day}/{month}/{year}";
+    //}
 
-    private static int JulianDayNumber(DateTime date)
-    {
-        int a = (14 - date.Month) / 12;
-        int y = date.Year + 4800 - a;
-        int m = date.Month + 12 * a - 3;
-        return date.Day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045;
-    }
+    //private static int JulianDayNumber(DateTime date)
+    //{
+    //    int a = (14 - date.Month) / 12;
+    //    int y = date.Year + 4800 - a;
+    //    int m = date.Month + 12 * a - 3;
+    //    return date.Day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045;
+    //}
 
-    private static string ToMayanLongCount(DateTime date)
-    {
-        int jdn = JulianDayNumber(date);
-        int days = jdn - 584283; // GMT correlation constant
-        int baktun = days / 144000;
-        int katun = (days % 144000) / 7200;
-        int tun = (days % 7200) / 360;
-        int uinal = (days % 360) / 20;
-        int kin = days % 20;
-        return $"{baktun}.{katun}.{tun}.{uinal}.{kin}";
-    }
+    //private static string ToMayanLongCount(DateTime date)
+    //{
+    //    int jdn = JulianDayNumber(date);
+    //    int days = jdn - 584283; // GMT correlation constant
+    //    int baktun = days / 144000;
+    //    int katun = (days % 144000) / 7200;
+    //    int tun = (days % 7200) / 360;
+    //    int uinal = (days % 360) / 20;
+    //    int kin = days % 20;
+    //    return $"{baktun}.{katun}.{tun}.{uinal}.{kin}";
+    //}
 
-    private static readonly string[] TzolkinNames = new[]
-    {
-        "Imix", "Ik'", "Ak'b'al", "K'an", "Chikchan",
-        "Kimi", "Manik'", "Lamat", "Muluk", "Ok",
-        "Chuwen", "Eb'", "Ben", "Ix", "Men",
-        "Kib'", "Kab'an", "Etz'nab'", "Kawak", "Ajaw"
-    };
+    //private static readonly string[] TzolkinNames = new[]
+    //{
+    //    "Imix", "Ik'", "Ak'b'al", "K'an", "Chikchan",
+    //    "Kimi", "Manik'", "Lamat", "Muluk", "Ok",
+    //    "Chuwen", "Eb'", "Ben", "Ix", "Men",
+    //    "Kib'", "Kab'an", "Etz'nab'", "Kawak", "Ajaw"
+    //};
 
-    private static string ToTzolkin(DateTime date)
-    {
-        int jdn = JulianDayNumber(date);
-        int days = jdn - 584283;
-        int number = ((days + 3) % 13) + 1; // 0.0.0.0.0 = 4 Ajaw
-        int nameIndex = (days + 19) % 20;
-        string name = TzolkinNames[nameIndex];
-        return $"{number} {name}";
-    }
+    //private static string ToTzolkin(DateTime date)
+    //{
+    //    int jdn = JulianDayNumber(date);
+    //    int days = jdn - 584283;
+    //    int number = ((days + 3) % 13) + 1; // 0.0.0.0.0 = 4 Ajaw
+    //    int nameIndex = (days + 19) % 20;
+    //    string name = TzolkinNames[nameIndex];
+    //    return $"{number} {name}";
+    //}
 
-    private static readonly string[] HaabMonths = new[]
-    {
-        "Pop", "Wo'", "Sip", "Sotz'", "Sek", "Xul", "Yaxk'in", "Mol",
-        "Ch'en", "Yax", "Sak", "Keh", "Mak", "K'ank'in", "Muwan", "Pax",
-        "K'ayab", "Kumk'u", "Wayeb"
-    };
+    //private static readonly string[] HaabMonths = new[]
+    //{
+    //    "Pop", "Wo'", "Sip", "Sotz'", "Sek", "Xul", "Yaxk'in", "Mol",
+    //    "Ch'en", "Yax", "Sak", "Keh", "Mak", "K'ank'in", "Muwan", "Pax",
+    //    "K'ayab", "Kumk'u", "Wayeb"
+    //};
 
-    private static string ToHaab(DateTime date)
-    {
-        int jdn = JulianDayNumber(date);
-        int days = jdn - 584283;
-        int count = (days + 348) % 365; // 0.0.0.0.0 = 8 Kumk'u
-        int month = count / 20;
-        int day = count % 20;
-        string monthName = HaabMonths[month];
-        return $"{day} {monthName}";
-    }
+    //private static string ToHaab(DateTime date)
+    //{
+    //    int jdn = JulianDayNumber(date);
+    //    int days = jdn - 584283;
+    //    int count = (days + 348) % 365; // 0.0.0.0.0 = 8 Kumk'u
+    //    int month = count / 20;
+    //    int day = count % 20;
+    //    string monthName = HaabMonths[month];
+    //    return $"{day} {monthName}";
+    //}
 
-    private static string ToHebrewString(DateTime date)
-    {
-        var hebrew = new System.Globalization.HebrewCalendar();
-        int year = hebrew.GetYear(date);
-        int month = hebrew.GetMonth(date);
-        int day = hebrew.GetDayOfMonth(date);
-        return $"{day}/{month}/{year}";
-    }
+    //private static string ToHebrewString(DateTime date)
+    //{
+    //    var hebrew = new System.Globalization.HebrewCalendar();
+    //    int year = hebrew.GetYear(date);
+    //    int month = hebrew.GetMonth(date);
+    //    int day = hebrew.GetDayOfMonth(date);
+    //    return $"{day}/{month}/{year}";
+    //}
 }

--- a/Calendar.Api/wwwroot/gematria.html
+++ b/Calendar.Api/wwwroot/gematria.html
@@ -154,11 +154,7 @@ function loadDate(dateString) {
         .then(d => {
             currentDates = d;
             const g = formatGregorian(d.gregorianDate);
-            dateInfoDiv.innerHTML = `Gregorian: ${g}<br>`+
-                `Julian: ${d.julianDate}<br>`+
-                `Hebrew: ${d.hebrewDate}<br>`+
-                `Tzolkin: ${d.tzolkin}<br>`+
-                `Haab: ${d.haab}`;
+            dateInfoDiv.innerHTML = `Gregorian: ${g}`;
         });
 }
 
@@ -218,11 +214,7 @@ function displayTeamResults(team, data, container) {
 
 function analyzeCalendars(team, dates) {
     const calStrings = {
-        'Gregorian': formatGregorian(dates.gregorianDate),
-        'Julian': dates.julianDate,
-        'Hebrew': dates.hebrewDate,
-        'Tzolkin': dates.tzolkin,
-        'Haab': dates.haab
+        'Gregorian': formatGregorian(dates.gregorianDate)
     };
     const out = {};
     for (const [name, val] of Object.entries(calStrings)) {

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Calendar API
 
-This project implements a simple multi‑calendar date calculation service based on the BRD requirements. It allows posting a start date and interval specification and returns the corresponding dates across several calendar systems.
-
-Date conversions for the Mayan Long Count, Tzolkin and Haab calendars use
-algorithms derived from the open source calendar utilities published by
-Fourmilab.
+This project implements a simple date calculation service. It previously returned dates across several calendar systems, but only the Gregorian calendar calculations are now enabled. Other calendar conversions remain in the code base but are commented out.
 
 ## Prerequisites
 - .NET SDK 7.0 or later
@@ -31,8 +27,7 @@ The response will include the generated dates for the next three days in all sup
 ```
 curl http://localhost:5000/api/date/current
 ```
-Returns the current date expressed in Gregorian, Julian, Hebrew, Mayan (Long Count),
-Tzolkin and Haab forms.
+Returns the current date expressed in Gregorian form.
 
 Migrations are not included because `dotnet ef` tools were unavailable in this
 environment. When running against a new SQL Server instance, create the initial


### PR DESCRIPTION
## Summary
- only keep Gregorian calendar conversions in `CalendarConversionService`
- comment out non-Gregorian properties in the data models
- stop persisting other calendar results in `CalculationsController`
- adjust gematria page to show only Gregorian date
- update README to mention Gregorian only

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687221878a70832eb4af2a8a80f624be