### PR TITLE
Add automatic round predictions

### DIFF
--- a/Calendar.Api/wwwroot/data/round.json
+++ b/Calendar.Api/wwwroot/data/round.json
@@ -1,0 +1,7 @@
+{
+  "games": [
+    { "homeTeam": "Adelaide Crows", "awayTeam": "Port Adelaide Power", "date": "2025-03-28" },
+    { "homeTeam": "Brisbane Lions", "awayTeam": "Carlton Blues", "date": "2025-03-29" },
+    { "homeTeam": "Collingwood Magpies", "awayTeam": "Richmond Tigers", "date": "2025-03-30" }
+  ]
+}

--- a/Calendar.Api/wwwroot/gematria.html
+++ b/Calendar.Api/wwwroot/gematria.html
@@ -81,6 +81,7 @@
         <button id="predict-btn">Predict Winner</button>
         <div id="prediction" style="font-weight:bold;margin-bottom:10px;"></div>
         <div id="calendar-results"></div>
+        <div id="round-results"></div>
     </div>
 
 <script>
@@ -268,6 +269,47 @@ function buildCalendarSection(name, teamA, teamB, dataA, dataB) {
     return { section: sec, pointsA, pointsB };
 }
 
+async function fetchCurrentRoundGames() {
+    const year = new Date().getUTCFullYear();
+    const apiUrl = `https://api.squiggle.com.au/?q=games;year=${year};next=1`;
+    try {
+        const res = await fetch(apiUrl);
+        if (!res.ok) throw new Error('api');
+        const data = await res.json();
+        if (data.games && data.games.length > 0) {
+            const upcomingRound = Math.min(...data.games.map(g => g.round));
+            return data.games.filter(g => g.round === upcomingRound).map(g => ({
+                teamA: g.hteam || g.homeTeam,
+                teamB: g.ateam || g.awayTeam,
+                date: g.date.substring(0,10)
+            }));
+        }
+    } catch (e) {
+        const res = await fetch('data/round.json');
+        const data = await res.json();
+        return data.games;
+    }
+    return [];
+}
+
+async function predictCurrentRound() {
+    const games = await fetchCurrentRoundGames();
+    const roundDiv = document.getElementById('round-results');
+    roundDiv.innerHTML = '';
+    for (const g of games) {
+        const dates = { gregorianDate: g.date };
+        const dataA = analyzeCalendars(g.teamA, dates);
+        const dataB = analyzeCalendars(g.teamB, dates);
+        const { section } = buildCalendarSection('Gregorian', g.teamA, g.teamB, dataA['Gregorian'], dataB['Gregorian']);
+        const wrapper = document.createElement('div');
+        const head = document.createElement('h2');
+        head.textContent = `${g.teamA} vs ${g.teamB} - ${formatGregorian(g.date)}`;
+        wrapper.appendChild(head);
+        wrapper.appendChild(section);
+        roundDiv.appendChild(wrapper);
+    }
+}
+
 
 function predict() {
     const teamA = teamSelectA.value;
@@ -304,6 +346,8 @@ function predict() {
     container.appendChild(summarySec);
 
     document.getElementById('prediction').textContent = overallWinner;
+
+    predictCurrentRound();
 }
 
 document.getElementById('predict-btn').addEventListener('click', predict);


### PR DESCRIPTION
## Summary
- provide sample AFL fixture data
- extend gematria predictor to fetch current round fixture
- run predictions for each scheduled match when clicking Predict

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687224a4a210832e81af85cd56bcfd46