### PR TITLE
Add AFL fixtures endpoint

### DIFF
--- a/Calendar.Api/Controllers/AflFixturesController.cs
+++ b/Calendar.Api/Controllers/AflFixturesController.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Calendar.Api.Services;
+using Calendar.Api.Models;
+
+namespace Calendar.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AflFixturesController : ControllerBase
+{
+    private readonly AflFixtureService _service;
+
+    public AflFixturesController(AflFixtureService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("current-round")]
+    public async Task<IEnumerable<AflGame>> GetCurrentRound()
+    {
+        return await _service.GetCurrentRoundAsync();
+    }
+}

--- a/Calendar.Api/Models/AflGame.cs
+++ b/Calendar.Api/Models/AflGame.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Calendar.Api.Models
+{
+    public class AflGame
+    {
+        public string HomeTeam { get; set; } = string.Empty;
+        public string AwayTeam { get; set; } = string.Empty;
+        public DateTime Date { get; set; }
+        public int Round { get; set; }
+    }
+}

--- a/Calendar.Api/Program.cs
+++ b/Calendar.Api/Program.cs
@@ -8,6 +8,7 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<CalendarConversionService>();
+builder.Services.AddHttpClient<AflFixtureService>();
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));

--- a/Calendar.Api/Services/AflFixtureService.cs
+++ b/Calendar.Api/Services/AflFixtureService.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Calendar.Api.Models;
+
+namespace Calendar.Api.Services;
+
+public class AflFixtureService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<AflFixtureService> _logger;
+
+    public AflFixtureService(HttpClient httpClient, ILogger<AflFixtureService> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<List<AflGame>> GetCurrentRoundAsync()
+    {
+        var games = new List<AflGame>();
+        try
+        {
+            var year = DateTime.UtcNow.Year;
+            var url = $"https://api.squiggle.com.au/?q=games;year={year};next=1";
+            using var res = await _httpClient.GetAsync(url);
+            res.EnsureSuccessStatusCode();
+            using var stream = await res.Content.ReadAsStreamAsync();
+            using var doc = await JsonDocument.ParseAsync(stream);
+            if (doc.RootElement.TryGetProperty("games", out var gamesEl))
+            {
+                var minRound = gamesEl.EnumerateArray()
+                    .Select(g => g.GetProperty("round").GetInt32())
+                    .Min();
+                foreach (var g in gamesEl.EnumerateArray())
+                {
+                    if (g.GetProperty("round").GetInt32() == minRound)
+                    {
+                        games.Add(new AflGame
+                        {
+                            HomeTeam = g.GetProperty("hteam").GetString() ?? g.GetProperty("homeTeam").GetString() ?? string.Empty,
+                            AwayTeam = g.GetProperty("ateam").GetString() ?? g.GetProperty("awayTeam").GetString() ?? string.Empty,
+                            Date = DateTime.Parse(g.GetProperty("date").GetString() ?? string.Empty),
+                            Round = minRound
+                        });
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to fetch AFL fixtures");
+        }
+        return games;
+    }
+}


### PR DESCRIPTION
## Summary
- add AflFixtureService to fetch current round fixture from Squiggle API
- register fixture service and create AflFixturesController
- expose new endpoint under `/api/AflFixtures/current-round`

## Testing
- `dotnet build Calender.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872274f10c0832e9bab08f18190fe03