### PR TITLE
Restore calendar conversions for lotto rules

### DIFF
--- a/Calendar.Api/Models/CalendarDate.cs
+++ b/Calendar.Api/Models/CalendarDate.cs
@@ -4,11 +4,11 @@ public class CalendarDate
 {
     public int Id { get; set; }
     public DateTime GregorianDate { get; set; }
-    //public string JulianDate { get; set; } = string.Empty;
-    //public string MayanLongCount { get; set; } = string.Empty;
-    //public string Tzolkin { get; set; } = string.Empty;
-    //public string Haab { get; set; } = string.Empty;
-    //public string HebrewDate { get; set; } = string.Empty;
+    public string JulianDate { get; set; } = string.Empty;
+    public string MayanLongCount { get; set; } = string.Empty;
+    public string Tzolkin { get; set; } = string.Empty;
+    public string Haab { get; set; } = string.Empty;
+    public string HebrewDate { get; set; } = string.Empty;
     public DateTime CreatedAt { get; set; }
     public string? CreatedBy { get; set; }
 }

--- a/Calendar.Api/Services/CalendarConversionService.cs
+++ b/Calendar.Api/Services/CalendarConversionService.cs
@@ -10,87 +10,87 @@ public class CalendarConversionService
         return new CalendarDate
         {
             GregorianDate = dateOnly,
-            //JulianDate = ToJulianString(dateOnly),
-            //MayanLongCount = ToMayanLongCount(dateOnly),
-            //Tzolkin = ToTzolkin(dateOnly),
-            //Haab = ToHaab(dateOnly),
-            //HebrewDate = ToHebrewString(dateOnly),
+            JulianDate = ToJulianString(dateOnly),
+            MayanLongCount = ToMayanLongCount(dateOnly),
+            Tzolkin = ToTzolkin(dateOnly),
+            Haab = ToHaab(dateOnly),
+            HebrewDate = ToHebrewString(dateOnly),
             CreatedAt = DateTime.UtcNow
         };
     }
 
-    //private static string ToJulianString(DateTime date)
-    //{
-    //    // Convert to the Julian calendar date string (day/month/year)
-    //    var julian = new System.Globalization.JulianCalendar();
-    //    int year = julian.GetYear(date);
-    //    int month = julian.GetMonth(date);
-    //    int day = julian.GetDayOfMonth(date);
-    //    return $"{day}/{month}/{year}";
-    //}
+    private static string ToJulianString(DateTime date)
+    {
+        // Convert to the Julian calendar date string (day/month/year)
+        var julian = new System.Globalization.JulianCalendar();
+        int year = julian.GetYear(date);
+        int month = julian.GetMonth(date);
+        int day = julian.GetDayOfMonth(date);
+        return $"{day}/{month}/{year}";
+    }
 
-    //private static int JulianDayNumber(DateTime date)
-    //{
-    //    int a = (14 - date.Month) / 12;
-    //    int y = date.Year + 4800 - a;
-    //    int m = date.Month + 12 * a - 3;
-    //    return date.Day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045;
-    //}
+    private static int JulianDayNumber(DateTime date)
+    {
+        int a = (14 - date.Month) / 12;
+        int y = date.Year + 4800 - a;
+        int m = date.Month + 12 * a - 3;
+        return date.Day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045;
+    }
 
-    //private static string ToMayanLongCount(DateTime date)
-    //{
-    //    int jdn = JulianDayNumber(date);
-    //    int days = jdn - 584283; // GMT correlation constant
-    //    int baktun = days / 144000;
-    //    int katun = (days % 144000) / 7200;
-    //    int tun = (days % 7200) / 360;
-    //    int uinal = (days % 360) / 20;
-    //    int kin = days % 20;
-    //    return $"{baktun}.{katun}.{tun}.{uinal}.{kin}";
-    //}
+    private static string ToMayanLongCount(DateTime date)
+    {
+        int jdn = JulianDayNumber(date);
+        int days = jdn - 584283; // GMT correlation constant
+        int baktun = days / 144000;
+        int katun = (days % 144000) / 7200;
+        int tun = (days % 7200) / 360;
+        int uinal = (days % 360) / 20;
+        int kin = days % 20;
+        return $"{baktun}.{katun}.{tun}.{uinal}.{kin}";
+    }
 
-    //private static readonly string[] TzolkinNames = new[]
-    //{
-    //    "Imix", "Ik'", "Ak'b'al", "K'an", "Chikchan",
-    //    "Kimi", "Manik'", "Lamat", "Muluk", "Ok",
-    //    "Chuwen", "Eb'", "Ben", "Ix", "Men",
-    //    "Kib'", "Kab'an", "Etz'nab'", "Kawak", "Ajaw"
-    //};
+    private static readonly string[] TzolkinNames = new[]
+    {
+        "Imix", "Ik'", "Ak'b'al", "K'an", "Chikchan",
+        "Kimi", "Manik'", "Lamat", "Muluk", "Ok",
+        "Chuwen", "Eb'", "Ben", "Ix", "Men",
+        "Kib'", "Kab'an", "Etz'nab'", "Kawak", "Ajaw"
+    };
 
-    //private static string ToTzolkin(DateTime date)
-    //{
-    //    int jdn = JulianDayNumber(date);
-    //    int days = jdn - 584283;
-    //    int number = ((days + 3) % 13) + 1; // 0.0.0.0.0 = 4 Ajaw
-    //    int nameIndex = (days + 19) % 20;
-    //    string name = TzolkinNames[nameIndex];
-    //    return $"{number} {name}";
-    //}
+    private static string ToTzolkin(DateTime date)
+    {
+        int jdn = JulianDayNumber(date);
+        int days = jdn - 584283;
+        int number = ((days + 3) % 13) + 1; // 0.0.0.0.0 = 4 Ajaw
+        int nameIndex = (days + 19) % 20;
+        string name = TzolkinNames[nameIndex];
+        return $"{number} {name}";
+    }
 
-    //private static readonly string[] HaabMonths = new[]
-    //{
-    //    "Pop", "Wo'", "Sip", "Sotz'", "Sek", "Xul", "Yaxk'in", "Mol",
-    //    "Ch'en", "Yax", "Sak", "Keh", "Mak", "K'ank'in", "Muwan", "Pax",
-    //    "K'ayab", "Kumk'u", "Wayeb"
-    //};
+    private static readonly string[] HaabMonths = new[]
+    {
+        "Pop", "Wo'", "Sip", "Sotz'", "Sek", "Xul", "Yaxk'in", "Mol",
+        "Ch'en", "Yax", "Sak", "Keh", "Mak", "K'ank'in", "Muwan", "Pax",
+        "K'ayab", "Kumk'u", "Wayeb"
+    };
 
-    //private static string ToHaab(DateTime date)
-    //{
-    //    int jdn = JulianDayNumber(date);
-    //    int days = jdn - 584283;
-    //    int count = (days + 348) % 365; // 0.0.0.0.0 = 8 Kumk'u
-    //    int month = count / 20;
-    //    int day = count % 20;
-    //    string monthName = HaabMonths[month];
-    //    return $"{day} {monthName}";
-    //}
+    private static string ToHaab(DateTime date)
+    {
+        int jdn = JulianDayNumber(date);
+        int days = jdn - 584283;
+        int count = (days + 348) % 365; // 0.0.0.0.0 = 8 Kumk'u
+        int month = count / 20;
+        int day = count % 20;
+        string monthName = HaabMonths[month];
+        return $"{day} {monthName}";
+    }
 
-    //private static string ToHebrewString(DateTime date)
-    //{
-    //    var hebrew = new System.Globalization.HebrewCalendar();
-    //    int year = hebrew.GetYear(date);
-    //    int month = hebrew.GetMonth(date);
-    //    int day = hebrew.GetDayOfMonth(date);
-    //    return $"{day}/{month}/{year}";
-    //}
+    private static string ToHebrewString(DateTime date)
+    {
+        var hebrew = new System.Globalization.HebrewCalendar();
+        int year = hebrew.GetYear(date);
+        int month = hebrew.GetMonth(date);
+        int day = hebrew.GetDayOfMonth(date);
+        return $"{day}/{month}/{year}";
+    }
 }


### PR DESCRIPTION
## Summary
- re-enable calendar conversion properties on `CalendarDate`
- reinstate conversion logic in `CalendarConversionService`

These fields are required by the prediction page to calculate Ozlotto and Powerball rules.

## Testing
- `dotnet build Calendar.Api/Calendar.Api.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687230789da8832ebc16f04917324861