### PR TITLE
Add date-root prediction logic

### DIFF
--- a/Calendar.Api/wwwroot/gematria.html
+++ b/Calendar.Api/wwwroot/gematria.html
@@ -129,6 +129,12 @@ function digitalRoot(num) {
     return num;
 }
 
+function dateToRoot(dateStr) {
+    const digits = dateStr.replace(/[^0-9]/g, '').split('').map(d => parseInt(d, 10));
+    let sum = digits.reduce((a,b) => a + b, 0);
+    return digitalRoot(sum);
+}
+
 const aflTeams = [
     "Adelaide Crows",
     "Brisbane Lions",
@@ -190,6 +196,7 @@ const teamSelectA = document.getElementById('team-a');
 const teamSelectB = document.getElementById('team-b');
 const headingEl = document.getElementById('predictor-heading');
 let currentDates = null;
+let currentDateRoot = null;
 
 function populateTeams() {
     teamSelectA.innerHTML = '';
@@ -232,7 +239,8 @@ function loadDate(dateString) {
         .then(d => {
             currentDates = d;
             const g = formatGregorian(d.gregorianDate);
-            dateInfoDiv.innerHTML = `Gregorian: ${g}`;
+            currentDateRoot = dateToRoot(dateString);
+            dateInfoDiv.innerHTML = `Gregorian: ${g} (Root ${currentDateRoot})`;
         });
 }
 
@@ -312,15 +320,29 @@ function phraseScore(item) {
     return 0;
 }
 
-function computePoints(dataA, dataB) {
+function computeYesNoPoints(dataA, dataB) {
     let pointsA = 0, pointsB = 0;
     dataA.forEach(p => { pointsA += phraseScore(p); });
     dataB.forEach(p => { pointsB += phraseScore(p); });
     return { pointsA, pointsB };
 }
 
+function phraseScoreDateRoot(item, target) {
+    if (item.root !== target) return 0;
+    if (item.category === 'win') return 1;
+    if (item.category === 'lose') return -1;
+    return 0;
+}
+
+function computeDateRootPoints(dataA, dataB, target) {
+    let pointsA = 0, pointsB = 0;
+    dataA.forEach(p => { pointsA += phraseScoreDateRoot(p, target); });
+    dataB.forEach(p => { pointsB += phraseScoreDateRoot(p, target); });
+    return { pointsA, pointsB };
+}
+
 function buildCalendarSection(name, teamA, teamB, dataA, dataB) {
-    const { pointsA, pointsB } = computePoints(dataA, dataB);
+    const { pointsA, pointsB } = computeYesNoPoints(dataA, dataB);
     const sec = document.createElement('div');
     sec.className = 'calendar-section';
     const heading = document.createElement('h3');
@@ -360,28 +382,43 @@ function predict() {
 
     let totalA = 0;
     let totalB = 0;
+    let rootTotalA = 0;
+    let rootTotalB = 0;
     Object.keys(dataA).forEach(cal => {
         const { section, pointsA, pointsB } = buildCalendarSection(cal, teamA, teamB, dataA[cal], dataB[cal]);
         totalA += pointsA;
         totalB += pointsB;
+        const rootPts = computeDateRootPoints(dataA[cal], dataB[cal], currentDateRoot);
+        rootTotalA += rootPts.pointsA;
+        rootTotalB += rootPts.pointsB;
         container.appendChild(section);
     });
 
     const summarySec = document.createElement('div');
     summarySec.className = 'calendar-section';
-    const heading = document.createElement('h3');
+    const headingYes = document.createElement('h3');
     let overallWinner;
     if (totalA > totalB) overallWinner = teamA;
     else if (totalB > totalA) overallWinner = teamB;
     else overallWinner = 'Draw';
-    heading.textContent = `Overall Predicted Winner: ${overallWinner}`;
-    summarySec.appendChild(heading);
+    headingYes.textContent = `Overall Predicted Winner (Yes/No): ${overallWinner}`;
+    summarySec.appendChild(headingYes);
+    const headingDate = document.createElement('h3');
+    let rootWinner;
+    if (rootTotalA > rootTotalB) rootWinner = teamA;
+    else if (rootTotalB > rootTotalA) rootWinner = teamB;
+    else rootWinner = 'Draw';
+    headingDate.textContent = `Predicted Winner (Date Root ${currentDateRoot}): ${rootWinner}`;
+    summarySec.appendChild(headingDate);
     const pointsInfo = document.createElement('div');
     pointsInfo.textContent = `${teamA} Total Points: ${totalA} | ${teamB} Total Points: ${totalB}`;
     summarySec.appendChild(pointsInfo);
+    const rootPoints = document.createElement('div');
+    rootPoints.textContent = `${teamA} Root Points: ${rootTotalA} | ${teamB} Root Points: ${rootTotalB}`;
+    summarySec.appendChild(rootPoints);
     container.appendChild(summarySec);
 
-    document.getElementById('prediction').textContent = overallWinner;
+    document.getElementById('prediction').textContent = `Yes/No: ${overallWinner}, Date Root: ${rootWinner}`;
 }
 
 document.getElementById('predict-btn').addEventListener('click', predict);
@@ -392,7 +429,7 @@ function computeGameScore(teamA, teamB) {
     let totalA = 0;
     let totalB = 0;
     Object.keys(dataA).forEach(cal => {
-        const { pointsA, pointsB } = computePoints(dataA[cal], dataB[cal]);
+        const { pointsA, pointsB } = computeYesNoPoints(dataA[cal], dataB[cal]);
         totalA += pointsA;
         totalB += pointsB;
     });


### PR DESCRIPTION
## Summary
- extend gematria page with date root scoring
- display both yes/no and date-root winners
- show the date's digital root in the UI

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687245153ddc832e880020f240f03ac7