### PR TITLE
Update date root logic for gematria scoring

### DIFF
--- a/Calendar.Api/wwwroot/gematria.html
+++ b/Calendar.Api/wwwroot/gematria.html
@@ -422,10 +422,12 @@ function computeYesNoPoints(dataA, dataB) {
 }
 
 // Calculate the score for a phrase relative to the provided date root.
-// Only phrases whose digital root matches the date root contribute points.
-// Win phrases contribute +1 and lose phrases contribute -1.
+// For each phrase we recompute the gematria digital root. If this single digit
+// matches the current date root, a win phrase contributes +1 and a lose phrase
+// contributes -1.
 function phraseScoreDateRoot(item, target) {
-    if (item.root !== target) {
+    const single = digitalRoot(gematriaValue(item.phrase));
+    if (single !== target) {
         return 0; // phrase does not match the current date root
     }
 


### PR DESCRIPTION
## Summary
- recompute each phrase's gematria single digit when applying Date Root scoring

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68725d262250832e99d6d225cc2fee5e