### PR TITLE
Fix date root scoring display

### DIFF
--- a/Calendar.Api/wwwroot/gematria.html
+++ b/Calendar.Api/wwwroot/gematria.html
@@ -371,7 +371,7 @@ function buildTeamTable(team, data) {
     table.className = 'phrase-table';
     const thead = table.createTHead();
     const hrow = thead.insertRow();
-    ['Phrase', 'Gematria', 'Match', 'Score'].forEach(t => {
+    ['Phrase', 'Gematria', 'Match', 'Score', 'Root Score'].forEach(t => {
         const th = document.createElement('th');
         th.textContent = t;
         hrow.appendChild(th);
@@ -380,9 +380,10 @@ function buildTeamTable(team, data) {
     data.forEach(item => {
         const row = tbody.insertRow();
         const score = phraseScore(item);
+        const rootScore = phraseScoreDateRoot(item, currentDateRoot);
         if (score > 0) row.className = 'positive';
         else if (score < 0) row.className = 'negative';
-        [item.phrase, item.value, item.root === currentDateRoot ? '✔' : '', score]
+        [item.phrase, item.value, item.root === currentDateRoot ? '✔' : '', score, rootScore]
             .forEach(val => {
                 const td = row.insertCell();
                 td.textContent = val;
@@ -422,10 +423,12 @@ function computeYesNoPoints(dataA, dataB) {
 }
 
 // Calculate the score for a phrase relative to the provided date root.
-// Only phrases whose digital root matches the date root contribute points.
-// Win phrases contribute +1 and lose phrases contribute -1.
+// For each phrase we recompute the gematria digital root. If this single digit
+// matches the current date root, a win phrase contributes +1 and a lose phrase
+// contributes -1.
 function phraseScoreDateRoot(item, target) {
-    if (item.root !== target) {
+    const single = digitalRoot(gematriaValue(item.phrase));
+    if (single !== target) {
         return 0; // phrase does not match the current date root
     }
 


### PR DESCRIPTION
## Summary
- show each phrase's date root score in the table
- recompute gematria digital root when scoring phrases

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68725d262250832e99d6d225cc2fee5e