### PR TITLE
Fix table header width

### DIFF
--- a/Calendar.Api/wwwroot/gematria.html
+++ b/Calendar.Api/wwwroot/gematria.html
@@ -391,7 +391,7 @@ function buildTeamTable(team, data, colorClass) {
     table.className = 'phrase-table';
     const thead = table.createTHead();
     const hrow = thead.insertRow();
-    ['Phrase', 'Gematria', 'Match', 'Score', 'Root Score'].forEach(t => {
+    ['Phrase', 'Gem', 'Match', 'Score', 'Root Score'].forEach(t => {
         const th = document.createElement('th');
         th.textContent = t;
         hrow.appendChild(th);


### PR DESCRIPTION
## Summary
- shorten Gematria column header in gematria table to save space

## Testing
- `dotnet build Calender.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687266530cf8832e82420e2e077a3849