### PR TITLE
Add name root scoring to gematria predictor

### DIFF
--- a/Calendar.Api/wwwroot/gematria.html
+++ b/Calendar.Api/wwwroot/gematria.html
@@ -229,6 +229,20 @@ function dateToRoot(dateStr) {
     return digitalRoot(sum);
 }
 
+function teamNameRootScore(team, target) {
+    const words = team.split(/\s+/).filter(w => w.length > 0);
+    const combos = [];
+    if (words.length > 0) combos.push(words[0]);
+    if (words.length > 1) combos.push(words[1]);
+    combos.push(team);
+    let score = 0;
+    combos.forEach(w => {
+        const root = digitalRoot(gematriaValue(w));
+        if (root === target) score++;
+    });
+    return score;
+}
+
 const aflTeams = [
     "Adelaide Crows",
     "Brisbane Lions",
@@ -581,6 +595,9 @@ function predict() {
         container.appendChild(section);
     });
 
+    rootTotalA += teamNameRootScore(teamA, currentDateRoot);
+    rootTotalB += teamNameRootScore(teamB, currentDateRoot);
+
     updatePredictionCard(teamA, teamB, totalA, totalB, rootTotalA, rootTotalB);
 }
 
@@ -601,6 +618,8 @@ function computeGameScore(teamA, teamB) {
         rootTotalA += rootPts.pointsA;
         rootTotalB += rootPts.pointsB;
     });
+    rootTotalA += teamNameRootScore(teamA, currentDateRoot);
+    rootTotalB += teamNameRootScore(teamB, currentDateRoot);
     let yesNoWinner = 'Draw';
     if (totalA > totalB) yesNoWinner = teamA;
     else if (totalB > totalA) yesNoWinner = teamB;


### PR DESCRIPTION
## Summary
- score each team name against the current date root
- include the name-based points when predicting winners

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687456cfafec832e893ebe01d97ea1b6