### PR TITLE
Handle Hebrew calendar range error

### DIFF
--- a/Calendar.Api/Services/CalendarConversionService.cs
+++ b/Calendar.Api/Services/CalendarConversionService.cs
@@ -88,6 +88,11 @@ public class CalendarConversionService
     private static string ToHebrewString(DateTime date)
     {
         var hebrew = new System.Globalization.HebrewCalendar();
+        if (date < hebrew.MinSupportedDateTime || date > hebrew.MaxSupportedDateTime)
+        {
+            return string.Empty;
+        }
+
         int year = hebrew.GetYear(date);
         int month = hebrew.GetMonth(date);
         int day = hebrew.GetDayOfMonth(date);

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ dotnet ef migrations add AddLottoEntries -p Calendar.Api -s Calendar.Api
 dotnet ef database update -p Calendar.Api -s Calendar.Api
 ```
 
+After adding support for supplement numbers, generate a follow-up migration so
+the additional columns exist in the database:
+
+```bash
+dotnet ef migrations add AddLottoSupplements -p Calendar.Api -s Calendar.Api
+dotnet ef database update -p Calendar.Api -s Calendar.Api
+```
+
 Viewing predictions on `/index.html` now records every calculated lotto number.
 Both matched and unmatched numbers are stored via the `/api/lottomatches`
 endpoint and can be queried by lotto name, draw date and match status.


### PR DESCRIPTION
## Summary
- avoid `ArgumentOutOfRangeException` in `CalendarConversionService` by checking the supported range for the `HebrewCalendar`
- document how to update the database to include supplement numbers for lotto entries

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bfcf4b078832ea6048e7a39b4d2f5