### PR TITLE
feat: expand super rule 6 calculations for Powerball

### DIFF
--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -811,13 +811,18 @@
                 const datePlus126Days = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 126));
 
                 const gDay126 = datePlus126Days.getUTCDate();
-                const gMonthDigits126 = (datePlus126Days.getUTCMonth() + 1).toString().split('').map(Number);
+                const gMonth126 = datePlus126Days.getUTCMonth() + 1;
+                const gMonthDigits126 = gMonth126.toString().split('').map(Number);
+                const gYear126 = datePlus126Days.getUTCFullYear();
                 const sr6g1 = gDay126;
                 const sr6g1Exp = `${gDay126}`;
                 results.push({ rule: 'Super Rule 6', value: sr6g1, exp: sr6g1Exp });
                 const sr6g2 = gDay126 + gMonthDigits126.reduce((a, b) => a + b, 0);
                 const sr6g2Exp = `${gDay126}+${gMonthDigits126.join('+')}`;
                 results.push({ rule: 'Super Rule 6', value: sr6g2, exp: sr6g2Exp });
+                const sr6g3 = gDay126 + gMonth126 + (gYear126 % 10);
+                const sr6g3Exp = `${gDay126}+${gMonth126}+${gYear126 % 10}`;
+                results.push({ rule: 'Super Rule 6', value: sr6g3, exp: sr6g3Exp });
 
                 const jdn126 = gregorianToJdn(datePlus126Days);
                 const j126 = jdnToJulian(jdn126);
@@ -828,17 +833,33 @@
                 const sr6j2 = j126.day + jMonthDigits126.reduce((a, b) => a + b, 0);
                 const sr6j2Exp = `${j126.day}+${jMonthDigits126.join('+')}`;
                 results.push({ rule: 'Super Rule 6', value: sr6j2, exp: sr6j2Exp });
+                const sr6j3 = j126.day + j126.month + (j126.year % 10);
+                const sr6j3Exp = `${j126.day}+${j126.month}+${j126.year % 10}`;
+                results.push({ rule: 'Super Rule 6', value: sr6j3, exp: sr6j3Exp });
 
                 const hebrewStr126 = new Intl.DateTimeFormat('en-u-ca-hebrew', { day: 'numeric', month: 'long', year: 'numeric' }).format(datePlus126Days);
                 const hebrewParts126 = hebrewStr126.split(' ');
                 const hDay126 = parseInt(hebrewParts126[0], 10);
                 const hMonth126 = hebrewMonthMap[hebrewParts126[1]] || 0;
+                const hYear126 = parseInt(hebrewParts126[2], 10);
                 const sr6h1 = hDay126;
                 const sr6h1Exp = `${hDay126}`;
                 results.push({ rule: 'Super Rule 6', value: sr6h1, exp: sr6h1Exp });
                 const sr6h2 = hDay126 + hMonth126 + CONST_9;
                 const sr6h2Exp = `${hDay126}+${hMonth126}+${CONST_9}`;
                 results.push({ rule: 'Super Rule 6', value: sr6h2, exp: sr6h2Exp });
+                const sr6h3 = hDay126 + hMonth126 + (hYear126 % 10);
+                const sr6h3Exp = `${hDay126}+${hMonth126}+${hYear126 % 10}`;
+                results.push({ rule: 'Super Rule 6', value: sr6h3, exp: sr6h3Exp });
+                const sr6hg = hDay126 + gMonth126;
+                const sr6hgExp = `${hDay126}+${gMonth126}`;
+                results.push({ rule: 'Super Rule 6', value: sr6hg, exp: sr6hgExp });
+                const sr6hm = parseInt(`${hMonth126}${gMonth126}`, 10);
+                const sr6hmExp = `${hMonth126}${gMonth126}`;
+                results.push({ rule: 'Super Rule 6', value: sr6hm, exp: sr6hmExp });
+                const sr6hj = hMonth126 + j126.month;
+                const sr6hjExp = `${hMonth126}+${j126.month}`;
+                results.push({ rule: 'Super Rule 6', value: sr6hj, exp: sr6hjExp });
             }
 
             currentResults = results;


### PR DESCRIPTION
## Summary
- extend Super Rule 6 to derive additional numbers from 126-day offsets across Gregorian, Julian, and Hebrew calendars
- add cross-calendar combinations such as Hebrew day plus Gregorian month and Hebrew/Julian month sums

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689542aaa0bc832ea4b4aafa1d3f24b6