### PR TITLE
Subtract 126 days when converting Gregorian dates

### DIFF
--- a/Calendar.Api/Services/CalendarConversionService.cs
+++ b/Calendar.Api/Services/CalendarConversionService.cs
@@ -6,15 +6,15 @@ public class CalendarConversionService
 {
     public CalendarDate Convert(DateTime gregorian)
     {
-        var dateOnly = gregorian.Date;
+        var adjusted = gregorian.Date.AddDays(-126);
         return new CalendarDate
         {
-            GregorianDate = dateOnly,
-            JulianDate = ToJulianString(dateOnly),
-            MayanLongCount = ToMayanLongCount(dateOnly),
-            Tzolkin = ToTzolkin(dateOnly),
-            Haab = ToHaab(dateOnly),
-            HebrewDate = ToHebrewString(dateOnly),
+            GregorianDate = adjusted,
+            JulianDate = ToJulianString(adjusted),
+            MayanLongCount = ToMayanLongCount(adjusted),
+            Tzolkin = ToTzolkin(adjusted),
+            Haab = ToHaab(adjusted),
+            HebrewDate = ToHebrewString(adjusted),
             CreatedAt = DateTime.UtcNow
         };
     }


### PR DESCRIPTION
## Summary
- ensure calendar conversion subtracts 126 days from the provided Gregorian date

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689549c4d97c832e8f04ad9c3805c3aa