### PR TITLE
Add Powerball Super Rule 7 calculation

### DIFF
--- a/Calendar.Api/Controllers/PowerballRulesController.cs
+++ b/Calendar.Api/Controllers/PowerballRulesController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Globalization;
+using System.Linq;
 
 namespace Calendar.Api.Controllers
 {
@@ -48,6 +49,26 @@ namespace Calendar.Api.Controllers
                 gregorianPlus9 = gPlus9,
                 hebrewPlus9 = hPlus9,
                 julianPlus9 = jPlus9
+            });
+        }
+
+        [HttpGet("superrule7")]
+        public ActionResult<object> GetSuperRule7()
+        {
+            DateTime today = DateTime.Today;
+            DateTime plusNine = today.AddDays(9);
+            DateTime minusNine = today.AddDays(-9);
+
+            int SumDigits(int value) => value.ToString().Sum(c => int.Parse(c.ToString()));
+
+            int total = SumDigits(plusNine.Day) + SumDigits(plusNine.Month) +
+                        SumDigits(minusNine.Day) + SumDigits(minusNine.Month);
+
+            return Ok(new
+            {
+                addedDate = plusNine.ToString("yyyy-MM-dd"),
+                subtractedDate = minusNine.ToString("yyyy-MM-dd"),
+                superRule7 = total
             });
         }
     }

--- a/README.md
+++ b/README.md
@@ -94,3 +94,25 @@ The response will include:
 
 
 ```
+
+### Powerball rules API
+
+The endpoint `/api/powerballrules/superrule7` applies Powerball Super Rule 7. It
+adds and subtracts nine days from today's Gregorian date and sums the digits of
+the resulting day and month values.
+
+Example:
+
+```bash
+curl "http://localhost:5000/api/powerballrules/superrule7"
+```
+
+Example response:
+
+```json
+{
+  "addedDate": "2023-08-16",
+  "subtractedDate": "2023-07-29",
+  "superRule7": 33
+}
+```


### PR DESCRIPTION
## Summary
- implement Powerball Super Rule 7 endpoint that sums digits from dates nine days before and after today
- document Super Rule 7 usage in the README

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955122282c832eadfe6b78d9d7c99e