### PR TITLE
Add Powerball Super Rule 7 calculation

### DIFF
--- a/Calendar.Api/Controllers/PowerballRulesController.cs
+++ b/Calendar.Api/Controllers/PowerballRulesController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Globalization;
+using System.Linq;
 
 namespace Calendar.Api.Controllers
 {
@@ -48,6 +49,26 @@ namespace Calendar.Api.Controllers
                 gregorianPlus9 = gPlus9,
                 hebrewPlus9 = hPlus9,
                 julianPlus9 = jPlus9
+            });
+        }
+
+        [HttpGet("superrule7")]
+        public ActionResult<object> GetSuperRule7()
+        {
+            DateTime today = DateTime.Today;
+            DateTime plusNine = today.AddDays(9);
+            DateTime minusNine = today.AddDays(-9);
+
+            int SumDigits(int value) => value.ToString().Sum(c => int.Parse(c.ToString()));
+
+            int total = SumDigits(plusNine.Day) + SumDigits(plusNine.Month) +
+                        SumDigits(minusNine.Day) + SumDigits(minusNine.Month);
+
+            return Ok(new
+            {
+                addedDate = plusNine.ToString("yyyy-MM-dd"),
+                subtractedDate = minusNine.ToString("yyyy-MM-dd"),
+                superRule7 = total
             });
         }
     }

--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -463,7 +463,7 @@
             }
         }
 
-        function ozlottoCalculations(date, use22 = false) {
+        async function ozlottoCalculations(date, use22 = false) {
 
             const CONST_21 = use22 ? 22 : 21;
             const CONST_11 = 11;
@@ -860,6 +860,18 @@
                 const sr6hj = hMonth126 + j126.month;
                 const sr6hjExp = `${hMonth126}+${j126.month}`;
                 results.push({ rule: 'Super Rule 6', value: sr6hj, exp: sr6hjExp });
+
+                const sr7Data = await fetch('/api/powerballrules/superrule7').then(r => r.json());
+                const addDate = new Date(sr7Data.addedDate + 'Z');
+                const subDate = new Date(sr7Data.subtractedDate + 'Z');
+                const sr7Digits = [
+                    ...addDate.getUTCDate().toString().split(''),
+                    ...(addDate.getUTCMonth() + 1).toString().split(''),
+                    ...subDate.getUTCDate().toString().split(''),
+                    ...(subDate.getUTCMonth() + 1).toString().split('')
+                ];
+                const sr7Exp = sr7Digits.join('+');
+                results.push({ rule: 'Super Rule 7', value: sr7Data.superRule7, exp: sr7Exp });
             }
 
             currentResults = results;
@@ -921,7 +933,7 @@
                 });
         }
 
-        function updateCalculations() {
+        async function updateCalculations() {
 
             const config = lotteryConstants[select.value];
             if (!config || !currentDates) {
@@ -932,7 +944,7 @@
             if (['Ozlotto', 'Powerball'].includes(select.value)) {
                 const g = new Date(currentDates.gregorianDate + 'Z');
                 const use22 = select.value === 'Powerball';
-                ozlottoCalculations(g, use22);
+                await ozlottoCalculations(g, use22);
                 const firstConst = use22 ? 22 : 21;
                 display.textContent = `Constants: ${firstConst}, 11, 18, 10`;
                 return;

--- a/README.md
+++ b/README.md
@@ -94,3 +94,25 @@ The response will include:
 
 
 ```
+
+### Powerball rules API
+
+The endpoint `/api/powerballrules/superrule7` applies Powerball Super Rule 7. It
+adds and subtracts nine days from today's Gregorian date and sums the digits of
+the resulting day and month values.
+
+Example:
+
+```bash
+curl "http://localhost:5000/api/powerballrules/superrule7"
+```
+
+Example response:
+
+```json
+{
+  "addedDate": "2023-08-16",
+  "subtractedDate": "2023-07-29",
+  "superRule7": 33
+}
+```


### PR DESCRIPTION
## Summary
- implement Powerball Super Rule 7 endpoint that sums digits from dates nine days before and after today
- display Super Rule 7 result on prediction page and await rule calculations

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68955122282c832eadfe6b78d9d7c99e