### PR TITLE
Use selected date for Powerball Super Rule 7

### DIFF
--- a/Calendar.Api/Controllers/PowerballRulesController.cs
+++ b/Calendar.Api/Controllers/PowerballRulesController.cs
@@ -53,11 +53,11 @@ namespace Calendar.Api.Controllers
         }
 
         [HttpGet("superrule7")]
-        public ActionResult<object> GetSuperRule7()
+        public ActionResult<object> GetSuperRule7([FromQuery] DateTime? date)
         {
-            DateTime today = DateTime.Today;
-            DateTime plusNine = today.AddDays(9);
-            DateTime minusNine = today.AddDays(-9);
+            DateTime baseDate = (date ?? DateTime.Today).Date;
+            DateTime plusNine = baseDate.AddDays(9);
+            DateTime minusNine = baseDate.AddDays(-9);
 
             int SumDigits(int value) => value.ToString().Sum(c => int.Parse(c.ToString()));
 

--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -861,7 +861,8 @@
                 const sr6hjExp = `${hMonth126}+${j126.month}`;
                 results.push({ rule: 'Super Rule 6', value: sr6hj, exp: sr6hjExp });
 
-                const sr7Data = await fetch('/api/powerballrules/superrule7').then(r => r.json());
+                const dateStr = date.toISOString().split('T')[0];
+                const sr7Data = await fetch(`/api/powerballrules/superrule7?date=${dateStr}`).then(r => r.json());
                 const addDate = new Date(sr7Data.addedDate + 'Z');
                 const subDate = new Date(sr7Data.subtractedDate + 'Z');
                 const sr7Digits = [


### PR DESCRIPTION
## Summary
- Compute Powerball Super Rule 7 from a provided draw date
- Send the selected date from the frontend when requesting Super Rule 7

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed 403)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689555fb7fbc832e8a47d30db6501824