### PR TITLE
Add Tattslotto System 126 endpoint

### DIFF
--- a/Calendar.Api/Controllers/TattslottoRulesController.cs
+++ b/Calendar.Api/Controllers/TattslottoRulesController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Calendar.Api.Services;
 
 namespace Calendar.Api.Controllers
 {
@@ -8,12 +10,19 @@ namespace Calendar.Api.Controllers
     [Route("api/[controller]")]
     public class TattslottoRulesController : ControllerBase
     {
+        private readonly CalendarConversionService _converter;
+
+        public TattslottoRulesController(CalendarConversionService converter)
+        {
+            _converter = converter;
+        }
+
         private static readonly Dictionary<int, int> DateMatrix = new()
         {
              {1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}, {7,7}, {8,8}, {9,9},
               {10,10}, {11,11}, {12,12}, {13,13}, {14,14}, {15,15}, {16,16}, {17,17}, {18,18},
               {19,19}, {20,20}, {21,22}, {22,22}, {23,23}, {24,24}, {25,25}, {26,26},
-              {27,27}, {28,28}, {29,29}, {30,30}, {31,31}
+              {27,27}, {28,28}, {29,29}, {30,30}, {31,31},
         };
 
         [HttpGet]
@@ -29,6 +38,37 @@ namespace Calendar.Api.Controllers
             return Ok(new { rule16 = r16 });
         }
 
+        [HttpGet("system126")]
+        public ActionResult<object> GetSystem126([FromQuery] DateTime? date)
+        {
+            DateTime baseDate = (date ?? DateTime.Today).Date;
+
+            int SumDigits(int value) => value.ToString().Sum(c => int.Parse(c.ToString()));
+            int SumDateDigits(DateTime d) => SumDigits(d.Day) + SumDigits(d.Month) + SumDigits(d.Year);
+
+            object Build(DateTime d)
+            {
+                var conv = _converter.Convert(d);
+                return new
+                {
+                    gregorianDate = conv.GregorianDate.ToString("yyyy-MM-dd"),
+                    digitSum = SumDateDigits(d),
+                    julianDate = conv.JulianDate,
+                    mayanLongCount = conv.MayanLongCount,
+                    tzolkin = conv.Tzolkin,
+                    haab = conv.Haab,
+                    hebrewDate = conv.HebrewDate
+                };
+            }
+
+            var days = Build(baseDate.AddDays(126));
+            var months = Build(baseDate.AddMonths(126));
+            var weeks = Build(baseDate.AddDays(126 * 7));
+            var years = Build(baseDate.AddYears(126));
+            var combined = Build(baseDate.AddYears(126).AddMonths(126).AddDays(126));
+
+            return Ok(new { days, months, weeks, years, combined });
+        }
 
         private static int Rule16(int day, int month, Dictionary<int, int> matrix)
         {
@@ -39,3 +79,4 @@ namespace Calendar.Api.Controllers
         }
     }
 }
+

--- a/README.md
+++ b/README.md
@@ -92,7 +92,16 @@ The response will include:
 
 { "rule16": 20 }
 
+```
 
+### Tattslotto system 126
+
+The endpoint `/api/tattslottorules/system126` adds 126 days, months, weeks and years to a base date (defaults to today) and returns each resulting date along with the sum of its digits and equivalent Julian, Mayan long count, Tzolkin, Haab and Hebrew dates.
+
+Example:
+
+```bash
+curl "http://localhost:5000/api/tattslottorules/system126"
 ```
 
 ### Powerball rules API


### PR DESCRIPTION
## Summary
- add System 126 endpoint for Tattslotto rules that offsets the base date by 126 days, months, weeks, years and a combined shift
- return digit sums and Julian, Mayan long count, Tzolkin, Haab and Hebrew conversions for each result
- document new Tattslotto System 126 endpoint in README

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6895b94d00d8832ebb35750cb59ac949