### PR TITLE
Add Tattslotto System 126 endpoint

### DIFF
--- a/Calendar.Api/Controllers/TattslottoRulesController.cs
+++ b/Calendar.Api/Controllers/TattslottoRulesController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Calendar.Api.Services;
 
 namespace Calendar.Api.Controllers
 {
@@ -8,12 +10,19 @@ namespace Calendar.Api.Controllers
     [Route("api/[controller]")]
     public class TattslottoRulesController : ControllerBase
     {
+        private readonly CalendarConversionService _converter;
+
+        public TattslottoRulesController(CalendarConversionService converter)
+        {
+            _converter = converter;
+        }
+
         private static readonly Dictionary<int, int> DateMatrix = new()
         {
              {1,1}, {2,2}, {3,3}, {4,4}, {5,5}, {6,6}, {7,7}, {8,8}, {9,9},
               {10,10}, {11,11}, {12,12}, {13,13}, {14,14}, {15,15}, {16,16}, {17,17}, {18,18},
               {19,19}, {20,20}, {21,22}, {22,22}, {23,23}, {24,24}, {25,25}, {26,26},
-              {27,27}, {28,28}, {29,29}, {30,30}, {31,31}
+              {27,27}, {28,28}, {29,29}, {30,30}, {31,31},
         };
 
         [HttpGet]
@@ -29,6 +38,37 @@ namespace Calendar.Api.Controllers
             return Ok(new { rule16 = r16 });
         }
 
+        [HttpGet("system126")]
+        public ActionResult<object> GetSystem126([FromQuery] DateTime? date)
+        {
+            DateTime baseDate = (date ?? DateTime.Today).Date;
+
+            int SumDigits(int value) => value.ToString().Sum(c => int.Parse(c.ToString()));
+            int SumDateDigits(DateTime d) => SumDigits(d.Day) + SumDigits(d.Month) + SumDigits(d.Year);
+
+            object Build(DateTime d)
+            {
+                var conv = _converter.Convert(d);
+                return new
+                {
+                    gregorianDate = conv.GregorianDate.ToString("yyyy-MM-dd"),
+                    digitSum = SumDateDigits(d),
+                    julianDate = conv.JulianDate,
+                    mayanLongCount = conv.MayanLongCount,
+                    tzolkin = conv.Tzolkin,
+                    haab = conv.Haab,
+                    hebrewDate = conv.HebrewDate
+                };
+            }
+
+            var days = Build(baseDate.AddDays(126));
+            var months = Build(baseDate.AddMonths(126));
+            var weeks = Build(baseDate.AddDays(126 * 7));
+            var years = Build(baseDate.AddYears(126));
+            var combined = Build(baseDate.AddYears(126).AddMonths(126).AddDays(126));
+
+            return Ok(new { days, months, weeks, years, combined });
+        }
 
         private static int Rule16(int day, int month, Dictionary<int, int> matrix)
         {
@@ -39,3 +79,4 @@ namespace Calendar.Api.Controllers
         }
     }
 }
+

--- a/Calendar.Api/wwwroot/gematria.html
+++ b/Calendar.Api/wwwroot/gematria.html
@@ -169,6 +169,7 @@
         <a href="index.html">Predict</a>
         <a href="lotto-entry.html">Enter Numbers</a>
         <a href="gematria.html">Gematria</a>
+        <a href="system126.html">System 126</a>
     </nav>
     <div class="card">
         <h1>Gematria Calculator</h1>

--- a/Calendar.Api/wwwroot/index.html
+++ b/Calendar.Api/wwwroot/index.html
@@ -77,6 +77,7 @@
         <a href="index.html">Predict</a>
         <a href="lotto-entry.html">Enter Numbers</a>
         <a href="gematria.html">Gematria</a>
+        <a href="system126.html">System 126</a>
     </nav>
     <div class="card">
     <h1>Select a lottery</h1>

--- a/Calendar.Api/wwwroot/lotto-entry.html
+++ b/Calendar.Api/wwwroot/lotto-entry.html
@@ -69,6 +69,7 @@
         <a href="index.html">Predict</a>
         <a href="lotto-entry.html">Enter Numbers</a>
         <a href="gematria.html">Gematria</a>
+        <a href="system126.html">System 126</a>
     </nav>
     <div class="card">
         <h1>Enter Lotto Numbers</h1>

--- a/Calendar.Api/wwwroot/system126.html
+++ b/Calendar.Api/wwwroot/system126.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tattslotto System 126</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: Arial, Helvetica, sans-serif;
+            background: #f5f7fa;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding: 40px 0;
+            color: #333;
+        }
+        nav.main-nav {
+            margin-bottom: 20px;
+        }
+        nav.main-nav a {
+            margin: 0 10px;
+            color: #333;
+            text-decoration: none;
+            font-weight: bold;
+        }
+        .card {
+            background: #fff;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            padding: 20px 30px;
+            max-width: 800px;
+            width: 90%;
+        }
+        h1 {
+            margin-top: 0;
+            font-size: 1.5rem;
+            text-align: center;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 15px;
+        }
+        th, td {
+            border: 1px solid #ccc;
+            padding: 4px 6px;
+            text-align: left;
+        }
+        th {
+            background: #f0f0f0;
+        }
+    </style>
+</head>
+<body>
+    <nav class="main-nav">
+        <a href="index.html">Predict</a>
+        <a href="lotto-entry.html">Enter Numbers</a>
+        <a href="gematria.html">Gematria</a>
+        <a href="system126.html">System 126</a>
+    </nav>
+    <div class="card">
+        <h1>Tattslotto System 126</h1>
+        <input type="date" id="date-picker" style="width:100%;padding:8px;" />
+        <div id="results"></div>
+    </div>
+    <script>
+        const picker = document.getElementById('date-picker');
+        const resultsDiv = document.getElementById('results');
+
+        function render(data) {
+            const rows = Object.entries(data).map(([key, val]) => {
+                return `<tr><th>${key}</th>` +
+                    `<td>${val.gregorianDate}</td>` +
+                    `<td>${val.digitSum}</td>` +
+                    `<td>${val.julianDate}</td>` +
+                    `<td>${val.mayanLongCount}</td>` +
+                    `<td>${val.tzolkin}</td>` +
+                    `<td>${val.haab}</td>` +
+                    `<td>${val.hebrewDate}</td></tr>`;
+            }).join('');
+            resultsDiv.innerHTML = `<table><thead><tr><th>Offset</th><th>Gregorian</th><th>Digit Sum</th><th>Julian</th><th>Mayan Long Count</th><th>Tzolkin</th><th>Haab</th><th>Hebrew</th></tr></thead><tbody>${rows}</tbody></table>`;
+        }
+
+        function load(date) {
+            fetch(`/api/tattslottorules/system126?date=${date}`)
+                .then(r => r.json())
+                .then(render);
+        }
+
+        picker.addEventListener('change', () => load(picker.value));
+        const today = new Date().toISOString().split('T')[0];
+        picker.value = today;
+        load(today);
+    </script>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -92,7 +92,18 @@ The response will include:
 
 { "rule16": 20 }
 
+```
 
+### Tattslotto system 126
+
+The endpoint `/api/tattslottorules/system126` adds 126 days, months, weeks and years to a base date (defaults to today) and returns each resulting date along with the sum of its digits and equivalent Julian, Mayan long count, Tzolkin, Haab and Hebrew dates.
+
+A simple browser interface is available at `/system126.html` to explore these calculations.
+
+Example:
+
+```bash
+curl "http://localhost:5000/api/tattslottorules/system126"
 ```
 
 ### Powerball rules API


### PR DESCRIPTION
## Summary
- add System 126 endpoint for Tattslotto rules that offsets the base date by 126 days, months, weeks, years and a combined shift
- provide browser page to view System 126 calculations
- link System 126 page from existing UI and document availability

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895b94d00d8832ebb35750cb59ac949